### PR TITLE
Support response code range in OpenApi3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -42,12 +43,7 @@ jobs:
           echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
       - uses: actions/checkout@v3
       - name: 'Run: Compile, Test, Pack, Publish'
-        run: ./build.cmd Compile Test Pack Publish
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: ./build.cmd Compile Test Pack
       - name: 'Publish: NSwag.zip'
         uses: actions/upload-artifact@v3
         with:
@@ -68,27 +64,3 @@ jobs:
         with:
           name: NuGet Packages
           path: artifacts/*.nupkg
-  ubuntu-latest:
-    name: ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Run: Compile, Test, Pack, Publish'
-        run: ./build.cmd Compile Test Pack Publish
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-  macos-latest:
-    name: macos-latest
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Run: Compile, Test, Pack, Publish'
-        run: ./build.cmd Compile Test Pack Publish
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,17 +61,3 @@ jobs:
         with:
           name: NuGet Packages
           path: artifacts/*.nupkg
-  ubuntu-latest:
-    name: ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Run: Compile, Test, Pack'
-        run: ./build.cmd Compile Test Pack
-  macos-latest:
-    name: macos-latest
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Run: Compile, Test, Pack'
-        run: ./build.cmd Compile Test Pack

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
@@ -522,7 +522,7 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             var code = generator.GenerateFile();
 
             // Assert
-            Assert.Contains("if (StatusInRange(status_, \"5xx\"))", code);
+            Assert.Contains("if (StatusInRange(status_, new System.Text.RegularExpressions.Regex(\"^5\\d\\d$\"))", code);
         }
 
         [Fact]

--- a/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ResponseTests.cs
@@ -355,6 +355,177 @@ namespace NSwag.CodeGeneration.CSharp.Tests
         }
 
         [Fact]
+        public async Task When_response_code_is_a_range()
+        {
+            // Arrange
+            string json = @"{
+  ""openapi"": ""3.0.1"",
+  ""info"": {
+    ""title"": ""WebApplication"",
+    ""version"": ""1.0""
+  },
+  ""servers"": [
+    {
+      ""url"": ""/WebApplication""
+    }
+  ],
+  ""paths"": {
+    ""/Account/Authenticate"": {
+      ""post"": {
+        ""tags"": [
+          ""Account""
+        ],
+        ""requestBody"": {
+          ""content"": {
+            ""application/json"": {
+              ""schema"": {
+                ""$ref"": ""#/components/schemas/AuthenticationRequest""
+              }
+            }
+          }
+        },
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+              ""text/plain"": {
+                ""schema"": {
+                  ""type"": ""string""
+                }
+              }
+            }
+          },
+          ""400"": {
+            ""description"": ""Bad Request"",
+            ""content"": {
+              ""application/problem+json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/ValidationProblemDetails""
+                }
+              }
+            }
+          },
+          ""401"": {
+            ""description"": ""Unauthorized"",
+            ""content"": {
+              ""application/problem+json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/ProblemDetails""
+                }
+              }
+            }
+          },
+          ""415"": {
+            ""description"": ""Unsupported Media Type"",
+            ""content"": {
+              ""application/problem+json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/ProblemDetails""
+                }
+              }
+            }
+          },
+          ""5xx"": {
+            ""description"": ""Internal Server Error"",
+            ""content"": {
+              ""application/problem+json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/ProblemDetails""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  ""components"": {
+    ""schemas"": {
+      ""AuthenticationRequest"": {
+        ""type"": ""object"",
+        ""additionalProperties"": false
+      },
+      ""ValidationProblemDetails"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""type"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""title"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""status"": {
+            ""type"": ""integer"",
+            ""format"": ""int32"",
+            ""nullable"": true
+          },
+          ""detail"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""instance"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""errors"": {
+            ""type"": ""object"",
+            ""additionalProperties"": {
+              ""type"": ""array"",
+              ""items"": {
+                ""type"": ""string""
+              }
+            },
+            ""nullable"": true,
+            ""readOnly"": true
+          }
+        },
+        ""additionalProperties"": { }
+      },
+      ""ProblemDetails"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""type"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""title"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""status"": {
+            ""type"": ""integer"",
+            ""format"": ""int32"",
+            ""nullable"": true
+          },
+          ""detail"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          },
+          ""instance"": {
+            ""type"": ""string"",
+            ""nullable"": true
+          }
+        },
+        ""additionalProperties"": { }
+      }
+    }
+  }
+}";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            // Act
+            var settings = new CSharpClientGeneratorSettings { ClassName = "MyClass" };
+            var generator = new CSharpClientGenerator(document, settings);
+            var code = generator.GenerateFile();
+
+            // Assert
+            Assert.Contains("if (StatusInRange(status_, \"5xx\"))", code);
+        }
+
+        [Fact]
         public async Task When_responses_produce_primitive_types()
         {
             // Arrange

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -386,7 +386,7 @@
 
                     var status_ = (int)response_.StatusCode;
 {%     for response in operation.Responses -%}
-                    {% if response.StatusCodeIsInt %}if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %}){% else %}if (StatusInRange(status_, "{{ response.StatusCode }}")){% endif %}
+                    {% if response.StatusCodeIsInt %}if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %}){% else %}if (StatusInRange(status_, {{ response.CreateRegex }})){% endif %}
                     {
                         {% template Client.Class.ProcessResponse %}
                     }
@@ -469,12 +469,9 @@
         public string Text { get; }
     }
 
-    private bool StatusInRange(int value, string match)
+    private bool StatusInRange(int value, Regex match)
     {
-        var regexBody = match.Replace("x", "\\d", System.StringComparison.OrdinalIgnoreCase);
-        var result = System.Text.RegularExpressions.Regex.IsMatch(value.ToString(), "^" + regexBody + "$");
-
-        return result;
+        return match.IsMatch(value.ToString());
     }
 
     {% template Client.Class.ReadObjectResponse %}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -386,7 +386,7 @@
 
                     var status_ = (int)response_.StatusCode;
 {%     for response in operation.Responses -%}
-                    {% if response.StatusCodeIsInt %}if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %}){% else %}if (StatusInRange(status_, {{ response.CreateRegex }})){% endif %}
+                    {% if response.StatusCodeIsInt %}if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %}){% else %}if (StatusInRange(status_, {{ response.CreateRegexFoxCS }})){% endif %}
                     {
                         {% template Client.Class.ProcessResponse %}
                     }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -386,7 +386,7 @@
 
                     var status_ = (int)response_.StatusCode;
 {%     for response in operation.Responses -%}
-                    if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
+                    {% if response.StatusCodeIsInt %}if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %}){% else %}if (StatusInRange(status_, "{{ response.StatusCode }}")){% endif %}
                     {
                         {% template Client.Class.ProcessResponse %}
                     }
@@ -467,6 +467,14 @@
         public T Object { get; }
 
         public string Text { get; }
+    }
+
+    private bool StatusInRange(int value, string match)
+    {
+        var regexBody = match.Replace("x", "\\d", System.StringComparison.OrdinalIgnoreCase);
+        var result = System.Text.RegularExpressions.Regex.IsMatch(value.ToString(), "^" + regexBody + "$");
+
+        return result;
     }
 
     {% template Client.Class.ReadObjectResponse %}

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
@@ -74,7 +74,7 @@ namespace NSwag.CodeGeneration.TypeScript.Tests
             var code = gen.GenerateFile();
 
             // Assert
-            Assert.Contains("if (`${status}`.match('^5xX$'.replace(/x/gi, '\\\\d')))", code);
+            Assert.Contains("if (`${status}`.match(/^5\\d\\d$/))", code);
             Assert.Contains("if (status === 200)", code);
         }
     }

--- a/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
+++ b/src/NSwag.CodeGeneration.TypeScript.Tests/ResponseTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace NSwag.CodeGeneration.TypeScript.Tests
+{
+    public class ResponseTests
+    {
+        [Fact]
+        public async Task When_response_status_code_is_a_range()
+        {
+            var json = @"{
+              ""x-generator"": ""NSwag v13.5.0.0 (NJsonSchema v10.1.15.0 (Newtonsoft.Json v11.0.0.0))"",
+              ""openapi"": ""3.0.0"",
+              ""info"": {
+                ""title"": ""My Title"",
+                ""version"": ""1.0.0""
+              },
+              ""paths"": {
+                ""/api/AwesomeTest/DoStuff"": {
+                  ""post"": {
+                    ""tags"": [
+                      ""DoStuff""
+                    ],
+                    ""operationId"": ""AwesomeTest_DoStuff"",
+                    ""requestBody"": {
+                      ""content"": {
+                        ""text/html"": {
+                          ""schema"": {
+                            ""type"": ""string""
+                          }
+                        }
+                      }
+                    },
+                    ""responses"": {
+                      ""200"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""text/html"": {
+                            ""schema"": {
+                              ""type"": ""string""
+                            }
+                          }
+                        }
+                      },
+                      ""5xX"": {
+                        ""description"": """",
+                        ""content"": {
+                          ""text/html"": {
+                            ""schema"": {
+                              ""type"": ""string""
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+              },
+              ""components"": {}
+            }";
+
+            var document = await OpenApiDocument.FromJsonAsync(json);
+
+            var clientSettings = new TypeScriptClientGeneratorSettings
+            {
+                Template = TypeScriptTemplate.Axios,
+                TypeScriptGeneratorSettings =
+                {
+                  TypeScriptVersion = 1.8m
+                }
+            };
+
+            var gen = new TypeScriptClientGenerator(document, clientSettings);
+            var code = gen.GenerateFile();
+
+            // Assert
+            Assert.Contains("if (`${status}`.match('^5xX$'.replace(/x/gi, '\\\\d')))", code);
+            Assert.Contains("if (status === 200)", code);
+        }
+    }
+}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
@@ -3,7 +3,7 @@
 let _mappings: { source: any, target: any }[] = [];
 {% endif -%}
 {% for response in operation.Responses -%}
-{% if response.StatusCodeIsInt %}if (status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}){% else %}if (`${status}`.match('^{{ response.StatusCode }}$'.replace(/x/gi, '\\d'))){% endif %} {
+{% if response.StatusCodeIsInt %}if (status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}){% else %}if (`${status}`.match({{ response.CreateRegexForTS }})){% endif %} {
     {% template Client.ProcessResponse.HandleStatusCode %}
 } else {% endfor -%}
 {% if operation.HasDefaultResponse -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.ProcessResponse.liquid
@@ -3,7 +3,7 @@
 let _mappings: { source: any, target: any }[] = [];
 {% endif -%}
 {% for response in operation.Responses -%}
-if (status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}) {
+{% if response.StatusCodeIsInt %}if (status === {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status === 206{% endif %}){% else %}if (`${status}`.match('^{{ response.StatusCode }}$'.replace(/x/gi, '\\d'))){% endif %} {
     {% template Client.ProcessResponse.HandleStatusCode %}
 } else {% endfor -%}
 {% if operation.HasDefaultResponse -%}

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -61,6 +61,9 @@ namespace NSwag.CodeGeneration.Models
         /// <summary>Gets a value indicating whether to check for the chunked HTTP status code (206, true when file response and 200/204).</summary>
         public bool CheckChunkedStatusCode => IsFile && (StatusCode == "200" || StatusCode == "204");
 
+        /// <summary>Gets a flag to say if the StatusCode can be interpreted as an integer. (e.g. 5XX cannot be treated as a number)</summary>
+        public bool StatusCodeIsInt => int.TryParse(StatusCode, out _);
+
         /// <summary>Gets the type of the response.</summary>
         public string Type =>
             _response.IsBinary(_operation) ? _generator.GetBinaryResponseTypeName() :

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
 
@@ -63,6 +64,19 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets a flag to say if the StatusCode can be interpreted as an integer. (e.g. 5XX cannot be treated as a number)</summary>
         public bool StatusCodeIsInt => int.TryParse(StatusCode, out _);
+        public string CreateRegex {
+            get
+            {
+                if (Regex.IsMatch(StatusCode, @"^[xX\d]{3}$"))
+                {
+                    var regexBody = StatusCode.ToLower().Replace("x", "\\d");
+                    return $"new System.Text.RegularExpressions.Regex(\"^{regexBody}$\")";
+                }
+
+                // This will make the code non compilable and it is intentional because this StatusCode is not valid
+                return StatusCode;
+            }
+        }
 
         /// <summary>Gets the type of the response.</summary>
         public string Type =>

--- a/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
+++ b/src/NSwag.CodeGeneration/Models/ResponseModelBase.cs
@@ -64,13 +64,30 @@ namespace NSwag.CodeGeneration.Models
 
         /// <summary>Gets a flag to say if the StatusCode can be interpreted as an integer. (e.g. 5XX cannot be treated as a number)</summary>
         public bool StatusCodeIsInt => int.TryParse(StatusCode, out _);
-        public string CreateRegex {
+        
+        /// <summary>Creates the CSharp regex when StatusCode is not an integer </summary>
+        public string CreateRegexFoxCS {
             get
             {
                 if (Regex.IsMatch(StatusCode, @"^[xX\d]{3}$"))
                 {
                     var regexBody = StatusCode.ToLower().Replace("x", "\\d");
                     return $"new System.Text.RegularExpressions.Regex(\"^{regexBody}$\")";
+                }
+
+                // This will make the code non compilable and it is intentional because this StatusCode is not valid
+                return StatusCode;
+            }
+        }
+        
+        /// <summary>Creates the TypeScript regex when StatusCode is not an integer </summary>
+        public string CreateRegexForTS {
+            get
+            {
+                if (Regex.IsMatch(StatusCode, @"^[xX\d]{3}$"))
+                {
+                    var regexBody = StatusCode.ToLower().Replace("x", "\\d");
+                    return $"/^{regexBody}$/";
                 }
 
                 // This will make the code non compilable and it is intentional because this StatusCode is not valid

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET70Minimal_targetFramework=net7.0_generatesCode=True.verified.txt
@@ -397,6 +397,11 @@ namespace MyNamespace
             public string Text { get; }
         }
 
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
+        }
+
         public bool ReadResponseAsString { get; set; }
 
         protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
@@ -624,6 +629,11 @@ namespace MyNamespace
             public T Object { get; }
 
             public string Text { get; }
+        }
+
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
         }
 
         public bool ReadResponseAsString { get; set; }

--- a/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
+++ b/src/NSwag.ConsoleCore.Tests/GenerateSampleSpecificationTests.CheckCSharpClientsAsync_projectName=NSwag.Sample.NET80Minimal_targetFramework=net8.0_generatesCode=True.verified.txt
@@ -397,6 +397,11 @@ namespace MyNamespace
             public string Text { get; }
         }
 
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
+        }
+
         public bool ReadResponseAsString { get; set; }
 
         protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
@@ -624,6 +629,11 @@ namespace MyNamespace
             public T Object { get; }
 
             public string Text { get; }
+        }
+
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
         }
 
         public bool ReadResponseAsString { get; set; }

--- a/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET70Minimal/GeneratedClientsCs.gen
@@ -397,6 +397,11 @@ namespace MyNamespace
             public string Text { get; }
         }
 
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
+        }
+
         public bool ReadResponseAsString { get; set; }
 
         protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
@@ -624,6 +629,11 @@ namespace MyNamespace
             public T Object { get; }
 
             public string Text { get; }
+        }
+
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
         }
 
         public bool ReadResponseAsString { get; set; }

--- a/src/NSwag.Sample.NET80Minimal/GeneratedClientsCs.gen
+++ b/src/NSwag.Sample.NET80Minimal/GeneratedClientsCs.gen
@@ -397,6 +397,11 @@ namespace MyNamespace
             public string Text { get; }
         }
 
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
+        }
+
         public bool ReadResponseAsString { get; set; }
 
         protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
@@ -624,6 +629,11 @@ namespace MyNamespace
             public T Object { get; }
 
             public string Text { get; }
+        }
+
+        private bool StatusInRange(int value, Regex match)
+        {
+            return match.IsMatch(value.ToString());
         }
 
         public bool ReadResponseAsString { get; set; }


### PR DESCRIPTION
Currently the NSwag will generate "code == 4xx" in CSharp class if the OpenAPI document contains response code range 4xx.
And it leads to compile error.

This PR is to:
- cherry-pick the change suggested in https://github.com/RicoSuter/NSwag/pull/4204.
- update unit test
- remove the unnecessary build in build.yml